### PR TITLE
Do not fail on other Upnp responses

### DIFF
--- a/lib/DiscoveryStrategy/Upnp.js
+++ b/lib/DiscoveryStrategy/Upnp.js
@@ -82,7 +82,7 @@ class Upnp {
     var message = message.toString();
 
     let match = message.match(/hue-bridgeid: (.*?)\r\n/i);
-    if (!(1 in match)) {
+    if (!match || !(1 in match)) {
       return;
     }
 


### PR DESCRIPTION
My network has multiple Upnp servers. The responses from these devices made this line throw on a `null` in `match`. Made the check more robust.