### PR TITLE
Fix AbstractClipSensorConfig export

### DIFF
--- a/lib/SensorType/AbstractClipSensorConfig.js
+++ b/lib/SensorType/AbstractClipSensorConfig.js
@@ -52,4 +52,4 @@ class AbstractClipSensorConfig extends AbstractSensorConfig {
   }
 }
 
-module.exports = AbstractSensorConfig;
+module.exports = AbstractClipSensorConfig;


### PR DESCRIPTION
The `AbstractClipSensorConfig` module currently exports the basic sensor config instead of the CLIP sensor config. This PR fixes the export.