### PR TITLE
Add AbstractZLLSensorConfig module

### DIFF
--- a/lib/SensorType/AbstractZLLSensorConfig.js
+++ b/lib/SensorType/AbstractZLLSensorConfig.js
@@ -1,0 +1,91 @@
+'use strict';
+
+let AbstractSensorConfig = require('./AbstractSensorConfig');
+
+/**
+ * Abstract ZLL sensor config
+ */
+class AbstractZLLSensorConfig extends AbstractSensorConfig {
+  /**
+   * Get reachable
+   *
+   * @return {bool} True if reachable, false if not
+   */
+  get reachable() {
+    return this.attributes.get('reachable');
+  }
+
+  /**
+   * Get battery level
+   *
+   * @return {int} Battery level
+   */
+  get battery() {
+    return this.attributes.get('battery');
+  }
+
+  /**
+   * Get alert
+   *
+   * @return {string} Alert value
+   */
+  get alert() {
+    return this.attributes.get('alert');
+  }
+
+  /**
+   * Set alert
+   *
+   * @param {bool} value Alert value
+   */
+  set alert(value) {
+    this.attributes.set('alert', value);
+  }
+
+  /**
+   * Is user test?
+   *
+   * @return {bool} True if user test mode, false if not
+   */
+  get userTest() {
+    return this.attributes.get('usertest');
+  }
+
+  /**
+   * Set user test
+   *
+   * @param {bool} value True or false
+   */
+  set userTest(value) {
+    this.attributes.set('usertest', Boolean(value));
+  }
+
+  /**
+   * Get pending config
+   *
+   * @return {array} List of configs pending change on device
+   */
+  get pending() {
+    return this.attributes.get('pending');
+  }
+
+  /**
+   * LED indication?
+   *
+   * @return {bool} True if LED indication, false if not
+   */
+  get ledIndication() {
+    return this.attributes.get('ledindication');
+  }
+
+  /**
+   * Set LED indication
+   *
+   * @param {bool} value True or false
+   */
+  set ledIndication(value) {
+    this.attributes.set('ledindication', Boolean(value));
+  }
+}
+
+module.exports = AbstractZLLSensorConfig;

--- a/lib/SensorType/ZLLLightLevel/Config.js
+++ b/lib/SensorType/ZLLLightLevel/Config.js
@@ -1,14 +1,14 @@
 'use strict';
 
-let AbstractSensorConfig = require('../AbstractSensorConfig');
+let AbstractZLLSensorConfig = require('../AbstractZLLSensorConfig');
 
 /**
  * ZLLLightLevel sensor: Config
  */
-class Config extends AbstractSensorConfig {
+class Config extends AbstractZLLSensorConfig {
   /**
    * Get dark threshold
-   * 
+   *
    * @return {int} Dark threshold
    */
   get darkThreshold() {
@@ -17,7 +17,7 @@ class Config extends AbstractSensorConfig {
 
   /**
    * Set dark threshold
-   * 
+   *
    * @param {int} Threshold
    */
   set darkThreshold(threshold) {
@@ -26,7 +26,7 @@ class Config extends AbstractSensorConfig {
 
   /**
    * Get threshold offset
-   * 
+   *
    * @return {int} Threshold offset
    */
   get thresholdOffset() {
@@ -35,29 +35,11 @@ class Config extends AbstractSensorConfig {
 
   /**
    * Set threshold offset
-   * 
+   *
    * @param {int} Threshold
    */
   set thresholdOffest(threshold) {
     this.attributes.set('tholdoffset', parseInt(threshold, 10));
-  }
-
-  /**
-   * Get battery level
-   *
-   * @return {int} Battery level
-   */
-  get battery() {
-    return this.attributes.get('battery');
-  }
-
-  /**
-   * Get reachable
-   *
-   * @return {bool} True if reachable, false if not
-   */
-  get reachable() {
-    return this.attributes.get('reachable');
   }
 }
 

--- a/lib/SensorType/ZLLPresence/Config.js
+++ b/lib/SensorType/ZLLPresence/Config.js
@@ -1,11 +1,11 @@
 'use strict';
 
-let AbstractSensorConfig = require('../AbstractSensorConfig');
+let AbstractZLLSensorConfig = require('../AbstractZLLSensorConfig');
 
 /**
  * ZLLPresence sensor: Config
  */
-class Config extends AbstractSensorConfig {
+class Config extends AbstractZLLSensorConfig {
   /**
    * Get sensitivity
    *
@@ -22,60 +22,6 @@ class Config extends AbstractSensorConfig {
    */
   get maxSensitivity() {
     return this.attributes.get('sensitivitymax');
-  }
-
-  /**
-   * Is user test?
-   * 
-   * @return {bool} True if user test mode, false if not
-   */
-  get userTest() {
-    return this.attributes.get('usertest');
-  }
-
-  /**
-   * Set user test
-   * 
-   * @param {bool} value True or false
-   */
-  set userTest(value) {
-    this.attributes.set('usertest', Boolean(value));
-  }
-
-  /**
-   * Get pending config
-   * 
-   * @return {array} List of configs pending change on device
-   */
-  get pending() {
-    return this.attributes.get('pending');
-  }
-
-  /**
-   * LED indication?
-   * 
-   * @return {bool} True if LED indication, false if not
-   */
-  get ledIndication() {
-    return this.attributes.get('ledindication');
-  }
-
-  /**
-   * Set LED indication
-   * 
-   * @param {bool} value True or false
-   */
-  set ledIndication(value) {
-    this.attributes.set('ledindication', Boolean(value));
-  }
-
-  /**
-   * Get battery level
-   *
-   * @return {int} Battery level
-   */
-  get battery() {
-    return this.attributes.get('battery');
   }
 }
 

--- a/lib/SensorType/ZLLSwitch/Config.js
+++ b/lib/SensorType/ZLLSwitch/Config.js
@@ -1,37 +1,10 @@
 'use strict';
 
-let AbstractSensorConfig = require('../AbstractSensorConfig');
+let AbstractZLLSensorConfig = require('../AbstractZLLSensorConfig');
 
 /**
  * ZLLSwitch sensor: Config
  */
-class Config extends AbstractSensorConfig {
-  /**
-   * Get battery level
-   *
-   * @return {int} Battery level
-   */
-  get battery() {
-    return this.attributes.get('battery');
-  }
-
-  /**
-   * Get alert
-   * 
-   * @return {string} Alert value
-   */
-  get alert() {
-    return this.attributes.get('alert');
-  }
-
-  /**
-   * Get reachable
-   *
-   * @return {bool} True if reachable, false if not
-   */
-  get reachable() {
-    return this.attributes.get('reachable');
-  }
-}
+class Config extends AbstractZLLSensorConfig {}
 
 module.exports = Config;

--- a/lib/SensorType/ZLLTemperature/Config.js
+++ b/lib/SensorType/ZLLTemperature/Config.js
@@ -1,10 +1,10 @@
 'use strict';
 
-let AbstractSensorConfig = require('../AbstractSensorConfig');
+let AbstractZLLSensorConfig = require('../AbstractZLLSensorConfig');
 
 /**
  * ZLLTemperature sensor: Config
  */
-class Config extends AbstractSensorConfig {}
+class Config extends AbstractZLLSensorConfig {}
 
 module.exports = Config;

--- a/lib/SensorType/ZLLTemperature/Config.js
+++ b/lib/SensorType/ZLLTemperature/Config.js
@@ -1,10 +1,10 @@
 'use strict';
 
-let AbstractClipSensorConfig = require('../AbstractClipSensorConfig');
+let AbstractSensorConfig = require('../AbstractSensorConfig');
 
 /**
  * ZLLTemperature sensor: Config
  */
-class Config extends AbstractClipSensorConfig {}
+class Config extends AbstractSensorConfig {}
 
 module.exports = Config;


### PR DESCRIPTION
The CLIP sensors share the same config properties, the ZLL sensors currently don't. This PR adds a generic `AbstractZLLSensorConfig` module, based on the [general sensor resources](https://developers.meethue.com/documentation/supported-sensors#generalSensorResource). Some sensors may not support all the attributes. However, the Philips Hue API exposes the general sensor resources for all ZLL sensors.