### PR TITLE
Change scene update logic to use new scene api

### DIFF
--- a/lib/Accessor/Scenes.js
+++ b/lib/Accessor/Scenes.js
@@ -69,7 +69,6 @@ class Scenes extends AbstractAccessor {
   save(scene) {
     return Promise.all([
       this.client.invokeCommand(new SaveScene(scene)),
-      this.client.invokeCommand(new SaveSceneLightState(scene))
     ]).then(() => {
       return scene;
     });

--- a/lib/Command/Scene/SaveScene.js
+++ b/lib/Command/Scene/SaveScene.js
@@ -11,6 +11,17 @@ const ALLOWED_ATTRIBUTES = [
   'transitiontime',
 ];
 
+const LIGHT_STATE_MAP = {
+  'on':             'on',
+  'brightness':     'bri',
+  'hue':            'hue',
+  'saturation':     'sat',
+  'xy':             'xy',
+  'colorTemp':      'ct',
+  'effect':         'effect',
+  'transitionTime': 'transitiontime',
+};
+
 /**
  * Save scene command
  *
@@ -42,6 +53,7 @@ class SaveScene {
       data:   {}
     };
 
+
     let attributes = this.scene.attributes.getChanged();
     for (let key of ALLOWED_ATTRIBUTES) {
       if (key in attributes) {
@@ -49,10 +61,26 @@ class SaveScene {
       }
     }
 
+    // API 1.29: Setting lightstate supported
+    let lightStates = this.scene.lightStates.getChanged();
+
+    options.data.lightstates = {};
+
+    for (let lightId in lightStates) {
+      let light = lightStates[lightId];
+      options.data.lightstates[lightId] = {}
+      for (let key in light) {
+        if (key in LIGHT_STATE_MAP) {
+          options.data.lightstates[lightId][LIGHT_STATE_MAP[key]] = light[key];
+        }
+      }
+    }
+
     return client.getTransport()
       .sendRequest(options)
       .then(() => {
         this.scene.attributes.resetChanged();
+        this.scene.lightStates.resetChanged();
 
         return this.reloadSceneAttributes(client);
       });


### PR DESCRIPTION
API 1.29 introduced a way of updating all lights in a scene in one go.
This PR changes the scene update logic to use that.

I haven't deleted the old SaveSceneLightState in this PR, as it could be use as a fallback if you desire to support the old api as well.

My main reason for this fix is that updating all lights in a large scene results in 500 or connection reset from the hub, as it get's too many requests in a short time.